### PR TITLE
Add Support for Google Calendar APIv3

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -96,7 +96,11 @@ Requires API key, get one here: [Google API key](https://code.google.com/apis/co
 
 ### Google calendar
 
-You'll need to find the calendar's public feed URL. Don't panic, [read the instructions further down the page](#google-calendar-and-public-feed-urls)...
+Requires API key - [Google API key](https://code.google.com/apis/console/)
+
+```feedLocation``` should be your Google Calendar ID.
+
+```timeMin``` don't include this unless you want to show some past events (default from now) - format is ```Y-m-d\TH:i:sP```
 
 ```
 <ul>
@@ -107,6 +111,8 @@ You'll need to find the calendar's public feed URL. Don't panic, [read the instr
         &cacheTime=`CACHE_TIME_IN_SECONDS`
         &cacheName=`UNIQUE_NAME_FOR_CACHE_FILE`
         &feedLocation=`FEED LOCATION`
+        &apiKey=`SERVER API KEY`
+        &timeMin=`DEFAULT NOW`
     ]]
 </ul>
 ```

--- a/README.md
+++ b/README.md
@@ -362,12 +362,4 @@ Click the arrow beside the name of the calendar, then go to settings.
 
 ![Calendar Settings](http://pdincubus.github.com/JSONDerulo/img/cal-settings.png)
 
-Look down near the bottom of the first settings screen, you'll see the following:
-
-![Calendar XML feed button](http://pdincubus.github.com/JSONDerulo/img/cal-xml-button.png)
-
-Right click the XML button, and click "Copy link location". Use this link as the &feedLocation in the snippet call. Easy!
-
-![Calendar XML feed location](http://pdincubus.github.com/JSONDerulo/img/cal-copy-link.png)
-
-The link should look something like this: ```str1ng0fr4nd0mch4r5%40group.calendar.google.com```
+Scroll down to find your Calendar ID and use it as the feedLocation parameter - it should look like this: ```str1ng0fr4nd0mch4r5@group.calendar.google.com```

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@ For all info: https://github.com/pdincubus/JSONDerulo/
 Most recent additions
 ---------------------
 
+2.5.0:
+    * NEW! Added support for Google Calendar API v3
+    
 2.4.2:
     * Small tweak to tumblr feed (thanks to romangetman)
     * New placeholders for twitter feed: "in reply to" options and included missing favourite count


### PR DESCRIPTION
Phil awesome plugin! I've updated it to support Google Calendar APIv3 which closes #17 and #19.

It looks like v2 to v3 changed a lot! I've added timeMin as the start time to fetch results, default is now so it only pulls future events but I've allowed people to change it in case they want to show 2 weeks in the past as well.

I've also updated the readme to reflect the changes as well as the changelog.

Let me know if I need to change anything else otherwise I'll leave it to you to create the transport package!

Andrew